### PR TITLE
test(werewolves-assistant-web): add ci build and tests

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -50,6 +50,7 @@ on:
           - tailwindcss
           - sitemap
           - i18n-module
+          - werewolves-assistant
 jobs:
   init:
     runs-on: ubuntu-latest
@@ -140,6 +141,7 @@ jobs:
           - tailwindcss
           - sitemap
           - i18n-module
+          - werewolves-assistant
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -55,6 +55,7 @@ on:
           - tailwindcss
           - sitemap
           - i18n-module
+          - werewolves-assistant
 jobs:
   execute-selected-suite:
     timeout-minutes: 30

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -61,6 +61,7 @@ jobs:
           - tailwindcss
           - sitemap
           - i18n-module
+          - werewolves-assistant
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/tests/werewolves-assistant.ts
+++ b/tests/werewolves-assistant.ts
@@ -1,0 +1,17 @@
+import { runInRepo } from '../utils.ts'
+import type { RunOptions } from '../types.ts'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'antoinezanardi/werewolves-assistant-web',
+		build: ['build'],
+		test: [
+			'lint:fix',
+			'test:unit',
+			'docker:sandbox-api:start',
+			'test:cucumber:prepare',
+			'test:cucumber',
+		],
+	})
+}

--- a/tests/werewolves-assistant.ts
+++ b/tests/werewolves-assistant.ts
@@ -7,7 +7,6 @@ export async function test(options: RunOptions) {
 		repo: 'antoinezanardi/werewolves-assistant-web',
 		build: ['build'],
 		test: [
-			'lint:fix',
 			'test:unit',
 			'docker:sandbox-api:start',
 			'test:cucumber:prepare',

--- a/tests/werewolves-assistant.ts
+++ b/tests/werewolves-assistant.ts
@@ -4,7 +4,7 @@ import type { RunOptions } from '../types.ts'
 export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
-		repo: 'antoinezanardi/werewolves-assistant-web',
+		repo: 'antoinezanardi/werewolves-assistant-web-next',
 		build: ['build'],
 		test: [
 			'test:unit',


### PR DESCRIPTION
## 🚀 Why this PR

As suggested by @manniL, I added the CI steps of building and testing my Werewolves Assistant Nuxt app. It's a quick PR, I probably missed some things, feel free to let me know if it's the case.

You can check the base repository **[here](https://github.com/antoinezanardi/werewolves-assistant-web-next)**.

Thanks again for your interest for my project ❤️ 