### PR TITLE
test(werewolves-assistant-web): skip screenshots comparison

### DIFF
--- a/tests/werewolves-assistant.ts
+++ b/tests/werewolves-assistant.ts
@@ -10,7 +10,7 @@ export async function test(options: RunOptions) {
 			'test:unit',
 			'docker:sandbox-api:start',
 			'test:cucumber:prepare',
-			'test:cucumber',
+			'test:cucumber:skip-screenshots-comparison',
 		],
 	})
 }


### PR DESCRIPTION
As discussed in Discord, I added a way to skip screenshots comparisons during E2E tests.