### PR TITLE
test(werewolves-assistant-web): sharded cucumber tests to prevent timeouts

### DIFF
--- a/tests/werewolves-assistant.ts
+++ b/tests/werewolves-assistant.ts
@@ -10,7 +10,10 @@ export async function test(options: RunOptions) {
 			'test:unit',
 			'docker:sandbox-api:start',
 			'test:cucumber:prepare',
-			'test:cucumber:skip-screenshots-comparison',
+			'test:cucumber:shard-1:skip-screenshots-comparison',
+			'test:cucumber:shard-2:skip-screenshots-comparison',
+			'test:cucumber:shard-3:skip-screenshots-comparison',
+			'test:cucumber:shard-4:skip-screenshots-comparison',
 		],
 	})
 }


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There is a 30 minutes timeout in CI to prevent any kind of infinite loops. Problem is, my e2e tests are longer than 30 minutes if run in synchronous way. I sharded the tests to solve the issue.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
