### PR TITLE
chore: also run ecosystem ci on windows

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -48,9 +48,12 @@ on:
 jobs:
   test-ecosystem:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
+        os:
+          - ubuntu
+          - windows
         suite:
           - starter
           - content


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Sometimes I run in errors that are specific to windows. Perhaps this is because most of the core developers in the nuxt ecosystemu seem to use linux/macos and the ci tests in the repos are also usually only run on ubuntu. 

It would be nice if such errors could be discovered before and not after a new release of a module/nuxt version. For this reason, we activate the ci-ecosystem tests also on windows.

Test run (3.x branch): https://github.com/tobiasdiez/ecosystem-ci/actions/runs/11026454120
Test run (main branch): https://github.com/tobiasdiez/ecosystem-ci/actions/runs/11026329086

There are a few modules that are indeed broken on Windows (but not on ubuntu). Most of these issues seem to be due to https://github.com/nuxtlabs/nuxt-component-meta/issues/72.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
