### PR TITLE
fix(werewolves-assistant-web): remove e2e tests to prevent timeout

### DIFF
--- a/tests/werewolves-assistant.ts
+++ b/tests/werewolves-assistant.ts
@@ -8,12 +8,6 @@ export async function test(options: RunOptions) {
     build: ['build'],
     test: [
       'test:unit',
-      'docker:sandbox-api:start',
-      'test:cucumber:prepare',
-      'test:cucumber:shard-1:skip-screenshots-comparison',
-      'test:cucumber:shard-2:skip-screenshots-comparison',
-      'test:cucumber:shard-3:skip-screenshots-comparison',
-      'test:cucumber:shard-4:skip-screenshots-comparison',
     ],
   })
 }


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Because the e2e tests are causing a timeout, I'm removing them until we can launch parallel jobs to prevent the 30 min limit.
