### PR TITLE
fix: override `unhead` to current Nuxt version

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -334,7 +334,7 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
       overrides.h3 ??= `npm:h3-nightly@latest`
     }
 
-		overrides.nuxt ??= `${options.nuxtPath}/packages/nuxt`
+    overrides.nuxt ??= `${options.nuxtPath}/packages/nuxt`
     overrides['@nuxt/kit'] ??= `${options.nuxtPath}/packages/kit`
     overrides['@nuxt/schema'] ??= `${options.nuxtPath}/packages/schema`
     overrides['@nuxt/vite-builder'] ??= `${options.nuxtPath}/packages/vite`
@@ -348,11 +348,11 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
       ),
     )
 
-		// ensure unhead is always the same version as @unhead/vue
-		overrides['@unhead/vue'] ??= devDependencies['@unhead/vue']
-		overrides.unhead ??= overrides['@unhead/vue']
+    // ensure unhead is always the same version as @unhead/vue
+    overrides['@unhead/vue'] ??= devDependencies['@unhead/vue']
+    overrides.unhead ??= overrides['@unhead/vue']
 
-		if (overrides['vue-router'] !== false) {
+    if (overrides['vue-router'] !== false) {
       overrides['vue-router'] ||= devDependencies?.['vue-router']
     }
     const vueResolution

--- a/utils.ts
+++ b/utils.ts
@@ -348,7 +348,7 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
       ),
     )
 
-    // ensure unhead is always the same version as @unhead/vue
+    // lock unhead to the same version as Nuxt's @unhead/vue
     overrides['@unhead/vue'] ??= devDependencies['@unhead/vue']
     overrides.unhead ??= overrides['@unhead/vue']
 

--- a/utils.ts
+++ b/utils.ts
@@ -334,7 +334,7 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
       overrides.h3 ??= `npm:h3-nightly@latest`
     }
 
-    overrides.nuxt ??= `${options.nuxtPath}/packages/nuxt`
+		overrides.nuxt ??= `${options.nuxtPath}/packages/nuxt`
     overrides['@nuxt/kit'] ??= `${options.nuxtPath}/packages/kit`
     overrides['@nuxt/schema'] ??= `${options.nuxtPath}/packages/schema`
     overrides['@nuxt/vite-builder'] ??= `${options.nuxtPath}/packages/vite`
@@ -347,7 +347,12 @@ export async function runInRepo(options: RunOptions & RepoOptions) {
         'utf-8',
       ),
     )
-    if (overrides['vue-router'] !== false) {
+
+		// ensure unhead is always the same version as @unhead/vue
+		overrides['@unhead/vue'] ??= devDependencies['@unhead/vue']
+		overrides.unhead ??= overrides['@unhead/vue']
+
+		if (overrides['vue-router'] !== false) {
       overrides['vue-router'] ||= devDependencies?.['vue-router']
     }
     const vueResolution


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As we're testing Unhead v2, some downstream packages are still loading the `unhead` v1 as part of their tests, we should override them to be in sync with whatever version Nuxt is using.

The packages using v1 is mostly due to `devDependencies` requirements or local overrides.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
