### PR TITLE
Include build-storybook script in nuxt ci checks

### DIFF
--- a/tests/storybook.ts
+++ b/tests/storybook.ts
@@ -5,7 +5,7 @@ export async function test(options: RunOptions) {
   await runInRepo({
     ...options,
     repo: 'nuxt-modules/storybook',
-    build: ['dev:prepare', 'build', 'dev:build', 'example:showcase:build'],
+    build: ['dev:prepare', 'build', 'dev:build', 'example:showcase:build', 'example:showcase:storybook:build'],
     test: ['test'],
     overrides: {
       vite: false,


### PR DESCRIPTION
### 🔗 Linked issue

No issue, this came up from a discussion on Discord!

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A recent release of nuxt broke the Storybook integration (only for build, not for dev), and the reason it wasn't caught in CI was because the build-storybook script is not run in CI. This PR fixes that.