### PR TITLE
feat: re-enable antoine-zanardi-portfolio in CI configurations

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -66,8 +66,8 @@ on:
           - tailwindcss
           - sitemap
           - i18n-module
-          - werewolves-assistant
-          # - antoine-zanardi-portfolio
+          # - werewolves-assistant
+          - antoine-zanardi-portfolio
           - storybook
 jobs:
   init:

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -71,8 +71,8 @@ on:
           - tailwindcss
           - sitemap
           - i18n-module
-          - werewolves-assistant
-          # - antoine-zanardi-portfolio
+          # - werewolves-assistant
+          - antoine-zanardi-portfolio
           - storybook
 jobs:
   execute-selected-suite:

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -78,7 +78,7 @@ jobs:
           - sitemap
           - i18n-module
           # - werewolves-assistant
-          # - antoine-zanardi-portfolio
+          - antoine-zanardi-portfolio
           - storybook
       fail-fast: false
     steps:


### PR DESCRIPTION
### 🔗 Linked issue

#20

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I re-enabled the antoinezanardi portfolio as it accepts now node version engines `>= 22`.

You can check this out in its own [package.json](https://github.com/antoinezanardi/antoinezanardi.fr/blob/master/package.json#L123).

I also commented the `werewolves-assistant` as it's not available for now.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
