### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict = true

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nuxt-ecosystem-ci",
   "type": "module",
   "version": "0.0.1",
-  "packageManager": "pnpm@10.25.0",
+  "packageManager": "pnpm@11.1.2",
   "description": "Nuxt Ecosystem CI",
   "license": "MIT",
   "homepage": "https://github.com/nuxt/ecosystem-ci#readme",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,7 @@
-onlyBuiltDependencies:
-  - simple-git-hooks
 
 strictPeerDependencies: false
-packageManagerStrict: false
+
+engineStrict: true
+
+allowBuilds:
+  simple-git-hooks: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,3 @@
-
 strictPeerDependencies: false
 
 engineStrict: true


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`