### PR TITLE
fix(ci): add new build approvals for self test 

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,6 @@ strictPeerDependencies: false
 engineStrict: true
 
 allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
   simple-git-hooks: true


### PR DESCRIPTION
The self test is broken as the `esbuild` and `@parcel/watcher` builds need approving, this fixes it by doing that. The CI in this PR will fail though as the chain needs to be merge on main for the fix to be included in the self test clone. I did successfully test this fix though by temporarily making it use the fixed version on this branch, so it should work well when merged.